### PR TITLE
Fix section box drag reset

### DIFF
--- a/src/components/SectionBox.tsx
+++ b/src/components/SectionBox.tsx
@@ -123,11 +123,12 @@ export const SectionBox: React.FC<SectionBoxProps> = ({ isActive, onDragStateCha
   const handlePointerDown = (e: ThreeEvent<PointerEvent>, handle: string) => {
     if (!bounds) return;
     e.stopPropagation();
-    
+
     setIsDragging(true);
     setDragHandle(handle);
     setDragAxis(handle.charAt(0) as 'x' | 'y' | 'z');
     setInitialMousePos({ x: e.clientX, y: e.clientY });
+    setUserModified(true);
     onDragStateChange?.(true);
     gl.domElement.style.cursor = 'grabbing';
     


### PR DESCRIPTION
## Summary
- keep section box dimensions when releasing drag

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af33c0d708321932e56247c0edb6d