### PR TITLE
Fix object selection interfering with transform controls

### DIFF
--- a/src/components/ObjectSelector.tsx
+++ b/src/components/ObjectSelector.tsx
@@ -28,6 +28,7 @@ export const ObjectSelector: React.FC<ObjectSelectorProps> = ({
         (child instanceof THREE.Mesh || child instanceof THREE.Points) &&
         !child.userData.isSectionBox &&
         !child.userData.isUI &&
+        !child.userData.isTransformControl &&
         !child.name.includes('helper') &&
         !child.name.includes('grid')
       ) {


### PR DESCRIPTION
## Summary
- avoid selecting transform control meshes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d7b562fc88321b1f735f7747c9a3a