### PR TITLE
Fix transform controls for non-scene objects

### DIFF
--- a/src/components/TransformManipulator.tsx
+++ b/src/components/TransformManipulator.tsx
@@ -27,12 +27,18 @@ export const TransformManipulator: React.FC<TransformManipulatorProps> = ({
 
     controls.enabled = isActive && !!object;
     if (controls.enabled) {
-      // Ensure all child matrices update correctly during manipulation
-      if (object) {
-        object.traverse((child: THREE.Object3D) => {
-          child.matrixAutoUpdate = true;
-        });
+      // Ensure we only attach objects that are part of the scene graph
+      if (!object || !object.parent) {
+        console.warn('TransformManipulator: object not in scene graph', object);
+        controls.enabled = false;
+        return;
       }
+
+      // Ensure all child matrices update correctly during manipulation
+      object.traverse((child: THREE.Object3D) => {
+        child.matrixAutoUpdate = true;
+      });
+
       controls.attach(object);
       controls.setMode(mode);
       controls.setSize(2.0);


### PR DESCRIPTION
## Summary
- check that objects are part of the scene before attaching `TransformControls`

## Testing
- `npm run lint` *(fails: 32 problems (13 errors, 19 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_686fc10243d08321b0084abb7c6d68d9